### PR TITLE
Fix ClangParser failing when godot_object_compiler/*.h not yet generated

### DIFF
--- a/src/library/parsers/libclang/parser.cpp
+++ b/src/library/parsers/libclang/parser.cpp
@@ -277,7 +277,8 @@ namespace GodotObjectCompiler
                     continue;
                 }
 
-                if (string_contains(spelling, ".generated.h")) {
+                if (string_contains(spelling, ".generated.h") ||
+                    string_contains(spelling, "godot_object_compiler")) {
                     // Skip error, file is not yet generated
                     continue;
                 }

--- a/tests/files/include_tests/generated_excluded.h
+++ b/tests/files/include_tests/generated_excluded.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/* generated_excluded.h                                                   */
+/*                        ___  ___  ___   ___ _____                       */
+/*                       / __|/ _ \|   \ / _ \_   _|                      */
+/*                      | (_ | (_) | |) | (_) || |                        */
+/*                       \___|\___/|___/ \___/ |_|                        */
+/*   ___  ___    _ ___ ___ _____    ___ ___  __  __ ___ ___ _    ___ ___  */
+/*  / _ \| _ )_ | | __/ __|_   _|  / __/ _ \|  \/  | _ \_ _| |  | __| _ \ */
+/* | (_) | _ \ || | _| (__  | |   | (_| (_) | |\/| |  _/| || |__| _||   / */
+/*  \___/|___/\__/|___\___| |_|    \___\___/|_|  |_|_| |___|____|___|_|_\ */
+/*                                                                        */
+/*              This file is part of Godot Object Compiler                */
+/*                  Copyright (c) 2026 Luca Ian Tuerk                     */
+/**************************************************************************/
+/*                            MIT LICENCE                                 */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+#pragma once
+
+#include "godot_object_compiler/core_includes.h"
+#include "godot_object_compiler/macros.h"
+#include "generated_excluded.generated.h"

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -70,6 +70,16 @@ int main(int argc, char* argv[])
         if ((parser->get_capabilities() & IParser::SOURCE_PARSER) == 0) {
             continue;
         }
+
+        {
+            Application application;
+            const Vector<String> args =
+                TestRegistry::instance()->get_test_application_arguments({"clear"});
+            PANIC_COND(
+                application.run(args),
+                "Failed to clear the cache before running tests with parser %s",
+                parser->get_type().c_str());
+        }
         Size timer_sum = 0;
         LibraryContext::instance()->set_default_parser(parser->get_type(), IParser::SOURCE_PARSER);
 
@@ -132,12 +142,7 @@ int main(int argc, char* argv[])
                     const Vector<String> args =
                         TestRegistry::instance()->get_test_application_arguments(
                             {"generate", "type_db"});
-                    if (application.run(args) != 0) {
-                        print_err("Failed to setup type db during test run.");
-                        PRINT_INFO("%s\tFailed!", test_name.c_str());
-                        failed_count++;
-                        continue;
-                    }
+                    PANIC_COND(application.run(args), "Failed to setup type db during test run.");
                 }
 
                 Ref<IParser> source_parser =

--- a/tests/parser/all.h
+++ b/tests/parser/all.h
@@ -4,5 +4,6 @@
 #include "enum_tests.h"
 #include "exclusion_tests.h"
 #include "extension_api_parser_tests.h"
+#include "include_tests.h"
 #include "macros_tests.h"
 #include "namespace_tests.h"

--- a/tests/parser/include_tests.h
+++ b/tests/parser/include_tests.h
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/* include_tests.h                                                        */
+/*                        ___  ___  ___   ___ _____                       */
+/*                       / __|/ _ \|   \ / _ \_   _|                      */
+/*                      | (_ | (_) | |) | (_) || |                        */
+/*                       \___|\___/|___/ \___/ |_|                        */
+/*   ___  ___    _ ___ ___ _____    ___ ___  __  __ ___ ___ _    ___ ___  */
+/*  / _ \| _ )_ | | __/ __|_   _|  / __/ _ \|  \/  | _ \_ _| |  | __| _ \ */
+/* | (_) | _ \ || | _| (__  | |   | (_| (_) | |\/| |  _/| || |__| _||   / */
+/*  \___/|___/\__/|___\___| |_|    \___\___/|_|  |_|_| |___|____|___|_|_\ */
+/*                                                                        */
+/*              This file is part of Godot Object Compiler                */
+/*                  Copyright (c) 2026 Luca Ian Tuerk                     */
+/**************************************************************************/
+/*                            MIT LICENCE                                 */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+#pragma once
+#include "library/tree/syntax/include.h"
+#include "library/tree/syntax/namespace.h"
+#include "test_registry.h"
+
+using namespace GodotObjectCompiler;
+
+GOC_TEST(GeneratedIncludesParsed)
+{
+    GOC_TEST_PARSE_FILE("tests/files/include_tests/generated_excluded.h");
+
+    auto includes = global_namespace->find_children<Include>(true);
+    GOC_TEST_ASSERT(includes.size() == 3, "Expected 3 includes");
+    GOC_TEST_ASSERT(
+        includes[0]->include_path == "godot_object_compiler/core_includes.h",
+        "Invalid second include path %s", includes[0]->include_path.c_str());
+    GOC_TEST_ASSERT(
+        includes[1]->include_path == "godot_object_compiler/macros.h",
+        "Invalid first include path %s", includes[1]->include_path.c_str());
+    GOC_TEST_ASSERT(
+        includes[2]->include_path == "generated_excluded.generated.h",
+        "Invalid third include path %s", includes[2]->include_path.c_str());
+    return TEST_RESULT_SUCCESS;
+};


### PR DESCRIPTION
Fixes #130 